### PR TITLE
Some clean-up to make this easier to run locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cesm/
+data_paths_loc.json

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 build: setup
 	jupyter-book build gallery
+	python code/inject_paths.py --reverse
 
 setup:
 	python code/setup_env.py
@@ -9,4 +10,5 @@ setup:
 
 clean:
 	python code/inject_paths.py --reverse
+	rm -f data_paths_loc.json
 	jupyter-book clean gallery --all

--- a/code/inject_paths.py
+++ b/code/inject_paths.py
@@ -7,7 +7,7 @@ import argparse
 
 def main(reverse=False):
 
-    with open(Path(__file__).parent / "data_paths.json", "r") as f:
+    with open(Path(__file__).parent / "data_paths_loc.json", "r") as f:
         paths = json.load(f)
     notebooks_path = Path(__file__).parent.parent / "gallery" / "notebooks"
 

--- a/code/set_cesm_path.py
+++ b/code/set_cesm_path.py
@@ -4,7 +4,8 @@ import sys
 from pathlib import Path
 
 
-path = Path(__file__).parent / "data_paths.json"
+path_in = Path(__file__).parent / "data_paths.json"
+path_out = Path(__file__).parent / "data_paths_loc.json"
 # Get CESM path from the first argument if provided, else from the CESMROOT environment variable
 if len(sys.argv) > 1:
     cesm_path = sys.argv[1]
@@ -19,10 +20,10 @@ else:
         sys.exit(1)
 
 # Load existing JSON
-with open(path) as f:
+with open(path_in) as f:
     data = json.load(f)
 
 # Update and save
 data["CESM"] = cesm_path
-with open(path, "w") as f:
+with open(path_out, "w") as f:
     json.dump(data, f, indent=2)

--- a/code/setup_env.py
+++ b/code/setup_env.py
@@ -14,7 +14,10 @@ data_dir = Path(__file__).parent.parent / "data"
 
 def main():
 
-    with open(Path(__file__).parent / "data_paths.json", "r") as f:
+    path_file = Path(__file__).parent / "data_paths_loc.json"
+    if not path_file.is_file():
+        path_file = Path(__file__).parent / "data_paths.json"
+    with open(path_file, "r") as f:
         paths = json.load(f)
 
     setup_glorys_credentials()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jupyter-book
 s3fs
 botocore==1.38.30
+copernicusmarine


### PR DESCRIPTION
1. The environment requires the `copernicusmarine` python package, so that has been added to the requirements file
2. Instead of overwriting `data_paths.json`, that file gets read in and the dictionary is written to `data_paths_loc.json` after it is modified; `data_paths_loc.json` is ignored by git
3. After running `jupyter-book`, `inject_paths.py --reverse` is run to avoid having modifications to the notebooks themselves in version control. Another approach would be to use the existing notebooks as a template (similar to `data_paths.json`) but that seems overly complicated.